### PR TITLE
Update README.md

### DIFF
--- a/packages/protocol/contracts/bridge/README.md
+++ b/packages/protocol/contracts/bridge/README.md
@@ -16,7 +16,7 @@ Let's go deeper into the steps that occur when bridging ETH from srcChain to des
 ### Send message / Send token
 
 The bridge distinguishes 4 different token types: `Ether`, `Erc20`, `Erc1155`, `Erc721`.
-Each type has it's own vault contract both deployed to the source and destination chain. (Except `EtherVault`, which is only deployed on L1 and Bridge itself holds the funds on L2.)
+Each type has its own vault contract both deployed to the source and destination chain. (Except `EtherVault`, which is only deployed on L1 and Bridge itself holds the funds on L2.)
 
 #### Bridging Ether
 


### PR DESCRIPTION
"Each type has it's own vault contract both deployed to the source and destination chain."

Correction: Replace "it's" with "its" as it is possessive, not a contraction of "it is". The sentence should be: "Each type has its own vault contract both deployed to the source and destination chain."